### PR TITLE
feat: add automatic downscaling when encountering OOM error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added automatic downscaling of the `rows_per_bucket` parameter for ways grouping operation [#50](https://github.com/kraina-ai/quackosm/issues/50)
+
 ## [0.4.4] - 2024-02-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ preview = true
 [tool.ruff]
 line-length = 100
 target-version = "py39"
+extend-exclude = ["old"]
+
+[tool.ruff.lint]
 select = [
     "E",
     "W",   # pycodestyle
@@ -138,12 +141,11 @@ select = [
     # "ANN",          # flake8-annotations
 ]
 ignore = ["D212"]
-extend-exclude = ["old"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.pycodestyle]
+[tool.ruff.lint.pycodestyle]
 max-doc-length = 100
 
 [tool.mypy]

--- a/quackosm/_osm_tags_filters.py
+++ b/quackosm/_osm_tags_filters.py
@@ -29,7 +29,7 @@ def merge_osm_tags_filter(osm_tags_filter: Iterable[GroupedOsmTagsFilter]) -> Os
 def merge_osm_tags_filter(
     osm_tags_filter: Union[
         OsmTagsFilter, GroupedOsmTagsFilter, Iterable[OsmTagsFilter], Iterable[GroupedOsmTagsFilter]
-    ]
+    ],
 ) -> OsmTagsFilter:
     """
     Merge OSM tags filter into `OsmTagsFilter` type.
@@ -52,12 +52,14 @@ def merge_osm_tags_filter(
     elif is_expected_type(osm_tags_filter, GroupedOsmTagsFilter):
         return _merge_grouped_osm_tags_filter(cast(GroupedOsmTagsFilter, osm_tags_filter))
     elif is_expected_type(osm_tags_filter, Iterable):
-        return _merge_multiple_osm_tags_filters([
-            merge_osm_tags_filter(
-                cast(Union[OsmTagsFilter, GroupedOsmTagsFilter], sub_osm_tags_filter)
-            )
-            for sub_osm_tags_filter in osm_tags_filter
-        ])
+        return _merge_multiple_osm_tags_filters(
+            [
+                merge_osm_tags_filter(
+                    cast(Union[OsmTagsFilter, GroupedOsmTagsFilter], sub_osm_tags_filter)
+                )
+                for sub_osm_tags_filter in osm_tags_filter
+            ]
+        )
 
     raise AttributeError(
         "Provided tags don't match required type definitions"

--- a/quackosm/_rich_progress.py
+++ b/quackosm/_rich_progress.py
@@ -8,6 +8,15 @@ __all__ = ["TaskProgressSpinner", "TaskProgressBar"]
 TOTAL_STEPS = 33
 
 
+def log_message(message: str) -> None:
+    try:  # pragma: no cover
+        from rich import print as rprint
+
+        rprint(message)
+    except ImportError:
+        print(message)
+
+
 class TaskProgressSpinner:
     def __init__(self, step_name: str, step_number: str):
         self.step_name = step_name

--- a/quackosm/pbf_file_reader.py
+++ b/quackosm/pbf_file_reader.py
@@ -1481,7 +1481,6 @@ class PbfFileReader:
                 ON r.id = fr.id
                 JOIN ({required_ways_with_linestrings.sql_query()}) w
                 ON w.id = r.ref
-                ORDER BY r.id, r.ref_idx
             ),
             any_outer_refs AS (
                 SELECT id, bool_or(ref_role == 'outer') any_outer_refs

--- a/quackosm/pbf_file_reader.py
+++ b/quackosm/pbf_file_reader.py
@@ -135,7 +135,7 @@ class PbfFileReader:
         self.working_directory.mkdir(parents=True, exist_ok=True)
         self.connection: duckdb.DuckDBPyConnection = None
 
-        self.rows_per_bucket = PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG[24]
+        self.rows_per_bucket = PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG[0]
         acutal_memory = psutil.virtual_memory()
         # If less than 8 / 16 / 24 GB total memory, reduce number of rows per group
         for memory_gb, rows_per_bucket in PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG.items():

--- a/quackosm/pbf_file_reader.py
+++ b/quackosm/pbf_file_reader.py
@@ -1254,7 +1254,7 @@ class PbfFileReader:
                     )
 
                 finished_operation = True
-            except duckdb.OutOfMemoryException:
+            except (duckdb.OutOfMemoryException, MemoryError):
                 if self.rows_per_bucket > PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG[0]:
                     self._delete_directories(
                         [destination_dir_path, grouped_ways_tmp_path, grouped_ways_path]
@@ -1370,7 +1370,9 @@ class PbfFileReader:
             self._save_parquet_file(
                 relation=ways_with_linestrings,
                 file_path=destination_dir_path / f"group={group}",
-                run_in_separate_process=self.rows_per_bucket > PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG[0],
+                run_in_separate_process=(
+                    self.rows_per_bucket > PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG[0]
+                ),
             )
             self._delete_directories(current_ways_group_path)
 

--- a/quackosm/pbf_file_reader.py
+++ b/quackosm/pbf_file_reader.py
@@ -1089,7 +1089,6 @@ class PbfFileReader:
                 while not r.ready():
                     acutal_memory = psutil.virtual_memory()
                     free_memory_ratio = acutal_memory.free / acutal_memory.total
-                    print(round(free_memory_ratio, 2))
                     if free_memory_ratio < 0.05:
                         # Will automatically call pool.terminate()
                         raise MemoryError()

--- a/quackosm/pbf_file_reader.py
+++ b/quackosm/pbf_file_reader.py
@@ -1370,7 +1370,7 @@ class PbfFileReader:
             self._save_parquet_file(
                 relation=ways_with_linestrings,
                 file_path=destination_dir_path / f"group={group}",
-                run_in_separate_process=True,
+                run_in_separate_process=self.rows_per_bucket > PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG[0],
             )
             self._delete_directories(current_ways_group_path)
 

--- a/quackosm/pbf_file_reader.py
+++ b/quackosm/pbf_file_reader.py
@@ -19,7 +19,6 @@ from typing import Any, Literal, NamedTuple, Optional, Union, cast
 import duckdb
 import geoarrow.pyarrow as ga
 import geopandas as gpd
-import psutil
 import pyarrow as pa
 import pyarrow.parquet as pq
 import shapely.wkt as wktlib
@@ -34,6 +33,7 @@ from quackosm._osm_way_polygon_features import OsmWayPolygonConfig, parse_dict_t
 from quackosm._rich_progress import (  # type: ignore[attr-defined]
     TaskProgressBar,
     TaskProgressSpinner,
+    log_message,
 )
 from quackosm._typing import is_expected_type
 from quackosm.osm_extracts import (
@@ -77,6 +77,13 @@ class PbfFileReader:
         relations_all_with_tags: "duckdb.DuckDBPyRelation"
         relations_with_unnested_way_refs: "duckdb.DuckDBPyRelation"
         relations_filtered_ids: "duckdb.DuckDBPyRelation"
+
+    ROWS_PER_BUCKET_MEMORY_CONFIG = {
+        0: 100_000,
+        8: 500_000,
+        16: 1_000_000,
+        24: 5_000_000,
+    }
 
     def __init__(
         self,
@@ -125,15 +132,15 @@ class PbfFileReader:
         self.working_directory.mkdir(parents=True, exist_ok=True)
         self.connection: duckdb.DuckDBPyConnection = None
 
-        self.rows_per_bucket = 5_000_000
-        memory = psutil.virtual_memory()
-        # If less than 8 / 16 / 24 GB total memory, reduce number of rows per group
-        if memory.total < (8 * (1024**3)):
-            self.rows_per_bucket = 100_000
-        elif memory.total < (16 * (1024**3)):
-            self.rows_per_bucket = 500_000
-        elif memory.total < (24 * (1024**3)):
-            self.rows_per_bucket = 1_000_000
+        self.rows_per_bucket = PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG[24]
+        # self.rows_per_bucket = PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG[0]
+        # acutal_memory = psutil.virtual_memory()
+        # # If less than 8 / 16 / 24 GB total memory, reduce number of rows per group
+        # for memory_gb, rows_per_bucket in PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG.items():
+        #     if acutal_memory.total >= (memory_gb * (1024**3)):
+        #         self.rows_per_bucket = rows_per_bucket
+        #     else:
+        #         break
 
         self.parquet_compression = parquet_compression
 
@@ -444,14 +451,18 @@ class PbfFileReader:
             self.connection.install_extension(extension_name)
             self.connection.load_extension(extension_name)
 
-        self.connection.sql("""
+        self.connection.sql(
+            """
             CREATE OR REPLACE MACRO linestring_to_linestring_wkt(ls) AS
             'LINESTRING (' || array_to_string([pt.x || ' ' || pt.y for pt in ls], ', ') || ')';
-        """)
-        self.connection.sql("""
+            """
+        )
+        self.connection.sql(
+            """
             CREATE OR REPLACE MACRO linestring_to_polygon_wkt(ls) AS
             'POLYGON ((' || array_to_string([pt.x || ' ' || pt.y for pt in ls], ', ') || '))';
-        """)
+            """
+        )
 
     def _parse_pbf_file(
         self,
@@ -543,13 +554,15 @@ class PbfFileReader:
                 ],
             )
 
-            parsed_geometries = self.connection.sql(f"""
+            parsed_geometries = self.connection.sql(
+                f"""
                 SELECT * FROM read_parquet([
                     '{filtered_nodes_with_geometry_path}/**',
                     '{filtered_ways_with_proper_geometry_path}/**',
                     '{filtered_relations_with_geometry_path}/**'
                 ]);
-            """)
+                """
+            )
 
             self._concatenate_results_to_geoparquet(
                 parsed_geometries=parsed_geometries,
@@ -749,11 +762,13 @@ class PbfFileReader:
             # - select all with more then one ref
             # - join all NV to refs
             # - select all where all refs has been joined (total_refs == found_refs)
-            self.connection.sql(f"""
+            self.connection.sql(
+                f"""
                 SELECT *
                 FROM ({elements.sql_query()}) w
                 WHERE kind = 'way' AND len(refs) >= 2
-            """).to_view("ways", replace=True)
+                """
+            ).to_view("ways", replace=True)
             ways_all_with_tags = self._sql_to_parquet_file(
                 sql_query=f"""
                 WITH filtered_tags AS (
@@ -837,13 +852,15 @@ class PbfFileReader:
             # - select all with type in ['boundary', 'multipolygon']
             # - join all WV to refs
             # - select all where all refs has been joined (total_refs == found_refs)
-            self.connection.sql(f"""
+            self.connection.sql(
+                f"""
                 SELECT *
                 FROM ({elements.sql_query()})
                 WHERE kind = 'relation' AND len(refs) > 0
                 AND list_contains(map_keys(tags), 'type')
                 AND list_has_any(map_extract(tags, 'type'), ['boundary', 'multipolygon'])
-            """).to_view("relations", replace=True)
+                """
+            ).to_view("relations", replace=True)
             relations_all_with_tags = self._sql_to_parquet_file(
                 sql_query=f"""
                 WITH filtered_tags AS (
@@ -1073,7 +1090,8 @@ class PbfFileReader:
     def _save_parquet_file(
         self, relation: "duckdb.DuckDBPyRelation", file_path: Path
     ) -> "duckdb.DuckDBPyRelation":
-        self.connection.sql(f"""
+        self.connection.sql(
+            f"""
             COPY (
                 SELECT * FROM ({relation.sql_query()})
             ) TO '{file_path}' (
@@ -1082,10 +1100,13 @@ class PbfFileReader:
                 ROW_GROUP_SIZE 25000,
                 COMPRESSION '{self.parquet_compression}'
             )
-        """)
-        return self.connection.sql(f"""
+            """
+        )
+        return self.connection.sql(
+            f"""
             SELECT * FROM read_parquet('{file_path}/**')
-        """)
+            """
+        )
 
     def _calculate_unique_ids_to_parquet(
         self, file_path: Path, result_path: Optional[Path] = None
@@ -1093,7 +1114,8 @@ class PbfFileReader:
         if result_path is None:
             result_path = file_path / "distinct"
 
-        self.connection.sql(f"""
+        self.connection.sql(
+            f"""
             COPY (
                 SELECT id FROM read_parquet('{file_path}/**') GROUP BY id
             ) TO '{result_path}' (
@@ -1102,24 +1124,25 @@ class PbfFileReader:
                 ROW_GROUP_SIZE 25000,
                 COMPRESSION '{self.parquet_compression}'
             )
-        """)
+            """
+        )
 
-        return self.connection.sql(f"""
-            SELECT * FROM read_parquet('{result_path}/**')
-        """)
+        return self.connection.sql(f"SELECT * FROM read_parquet('{result_path}/**')")
 
     def _get_filtered_nodes_with_geometry(
         self,
         osm_parquet_files: ConvertedOSMParquetFiles,
     ) -> Path:
-        nodes_with_geometry = self.connection.sql(f"""
+        nodes_with_geometry = self.connection.sql(
+            f"""
             SELECT
                 'node/' || n.id as feature_id,
                 n.tags,
                 ST_Point(round(n.lon, 7), round(n.lat, 7)) geometry
             FROM ({osm_parquet_files.nodes_valid_with_tags.sql_query()}) n
             SEMI JOIN ({osm_parquet_files.nodes_filtered_ids.sql_query()}) fn ON n.id = fn.id
-        """)
+            """
+        )
         result_path = self.tmp_dir_path / "filtered_nodes_with_geometry"
         self._save_parquet_file_with_geometry(
             relation=nodes_with_geometry,
@@ -1133,7 +1156,8 @@ class PbfFileReader:
         self,
         osm_parquet_files: ConvertedOSMParquetFiles,
     ) -> "duckdb.DuckDBPyRelation":
-        ways_refs_with_nodes_structs = self.connection.sql(f"""
+        ways_refs_with_nodes_structs = self.connection.sql(
+            f"""
             SELECT
                 w.id,
                 w.ref,
@@ -1141,7 +1165,8 @@ class PbfFileReader:
                 struct_pack(x := round(n.lon, 7), y := round(n.lat, 7))::POINT_2D point
             FROM ({osm_parquet_files.nodes_valid_with_tags.sql_query()}) n
             JOIN ({osm_parquet_files.ways_with_unnested_nodes_refs.sql_query()}) w ON w.ref = n.id
-        """)
+            """
+        )
         with TaskProgressSpinner("Saving required nodes with structs", "20"):
             ways_refs_parquet = self._save_parquet_file(
                 relation=ways_refs_with_nodes_structs,
@@ -1158,27 +1183,51 @@ class PbfFileReader:
         grouped_ways_tmp_path = self.tmp_dir_path / "filtered_ways_tmp"
         destination_dir_path = self.tmp_dir_path / "filtered_ways_with_linestrings"
 
-        with TaskProgressSpinner("Grouping filtered ways", "21"):
-            groups = self._group_ways(
-                ways_ids=osm_parquet_files.ways_filtered_ids,
-                destination_dir_path=destination_dir_path,
-                grouped_ways_tmp_path=grouped_ways_tmp_path,
-                grouped_ways_path=grouped_ways_path,
-                ways_refs_with_nodes_structs=ways_refs_with_nodes_structs,
-            )
-            self._delete_directories(grouped_ways_tmp_path)
+        finished_operation = False
 
-        with TaskProgressBar("Saving filtered ways with linestrings", "22") as bar:
-            self._construct_ways_linestrings(
-                bar=bar,
-                groups=groups,
-                destination_dir_path=destination_dir_path,
-                grouped_ways_path=grouped_ways_path,
-            )
+        while not finished_operation:
+            try:
+                with TaskProgressSpinner("Grouping filtered ways", "21"):
+                    groups = self._group_ways(
+                        ways_ids=osm_parquet_files.ways_filtered_ids,
+                        destination_dir_path=destination_dir_path,
+                        grouped_ways_tmp_path=grouped_ways_tmp_path,
+                        grouped_ways_path=grouped_ways_path,
+                        ways_refs_with_nodes_structs=ways_refs_with_nodes_structs,
+                    )
+                    self._delete_directories(grouped_ways_tmp_path)
 
-        ways_parquet = self.connection.sql(f"""
-            SELECT * FROM read_parquet('{destination_dir_path}/**')
-        """)
+                with TaskProgressBar("Saving filtered ways with linestrings", "22") as bar:
+                    self._construct_ways_linestrings(
+                        bar=bar,
+                        groups=groups,
+                        destination_dir_path=destination_dir_path,
+                        grouped_ways_path=grouped_ways_path,
+                    )
+
+                finished_operation = True
+            except duckdb.OutOfMemoryException:
+                if self.rows_per_bucket > PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG[0]:
+                    self._delete_directories(
+                        [destination_dir_path, grouped_ways_tmp_path, grouped_ways_path]
+                    )
+                    smaller_rows_per_bucket = 0
+                    for rows_per_bucket in PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG.values():
+                        if rows_per_bucket < self.rows_per_bucket:
+                            smaller_rows_per_bucket = rows_per_bucket
+                        else:
+                            break
+                    self.rows_per_bucket = smaller_rows_per_bucket
+                    log_message(
+                        "Encountered OutOfMemoryException during operation."
+                        f" Retrying with lower number of rows per group ({self.rows_per_bucket})."
+                    )
+                else:
+                    raise
+
+        ways_parquet = self.connection.sql(
+            f"SELECT * FROM read_parquet('{destination_dir_path}/**')"
+        )
         return ways_parquet
 
     def _get_required_ways_with_linestrings(
@@ -1190,27 +1239,51 @@ class PbfFileReader:
         grouped_ways_tmp_path = self.tmp_dir_path / "required_ways_tmp"
         destination_dir_path = self.tmp_dir_path / "required_ways_with_linestrings"
 
-        with TaskProgressSpinner("Grouping required ways", "23"):
-            groups = self._group_ways(
-                ways_ids=osm_parquet_files.ways_required_ids,
-                destination_dir_path=destination_dir_path,
-                grouped_ways_tmp_path=grouped_ways_tmp_path,
-                grouped_ways_path=grouped_ways_path,
-                ways_refs_with_nodes_structs=ways_refs_with_nodes_structs,
-            )
-            self._delete_directories(grouped_ways_tmp_path)
+        finished_operation = False
 
-        with TaskProgressBar("Saving required ways with linestrings", "24") as bar:
-            self._construct_ways_linestrings(
-                bar=bar,
-                groups=groups,
-                destination_dir_path=destination_dir_path,
-                grouped_ways_path=grouped_ways_path,
-            )
+        while not finished_operation:
+            try:
+                with TaskProgressSpinner("Grouping required ways", "23"):
+                    groups = self._group_ways(
+                        ways_ids=osm_parquet_files.ways_required_ids,
+                        destination_dir_path=destination_dir_path,
+                        grouped_ways_tmp_path=grouped_ways_tmp_path,
+                        grouped_ways_path=grouped_ways_path,
+                        ways_refs_with_nodes_structs=ways_refs_with_nodes_structs,
+                    )
+                    self._delete_directories(grouped_ways_tmp_path)
 
-        ways_parquet = self.connection.sql(f"""
-            SELECT * FROM read_parquet('{destination_dir_path}/**')
-        """)
+                with TaskProgressBar("Saving required ways with linestrings", "24") as bar:
+                    self._construct_ways_linestrings(
+                        bar=bar,
+                        groups=groups,
+                        destination_dir_path=destination_dir_path,
+                        grouped_ways_path=grouped_ways_path,
+                    )
+
+                finished_operation = True
+            except duckdb.OutOfMemoryException:
+                if self.rows_per_bucket > PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG[0]:
+                    self._delete_directories(
+                        [destination_dir_path, grouped_ways_tmp_path, grouped_ways_path]
+                    )
+                    smaller_rows_per_bucket = 0
+                    for rows_per_bucket in PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG.values():
+                        if rows_per_bucket < self.rows_per_bucket:
+                            smaller_rows_per_bucket = rows_per_bucket
+                        else:
+                            break
+                    self.rows_per_bucket = smaller_rows_per_bucket
+                    log_message(
+                        "Encountered OutOfMemoryException during operation."
+                        f" Retrying with lower number of rows per group ({self.rows_per_bucket})."
+                    )
+                else:
+                    raise
+
+        ways_parquet = self.connection.sql(
+            f"SELECT * FROM read_parquet('{destination_dir_path}/**')"
+        )
         return ways_parquet
 
     def _group_ways(
@@ -1234,32 +1307,37 @@ class PbfFileReader:
 
         groups = int(floor(total_required_ways / self.rows_per_bucket))
 
-        ways_ids_grouped_relation = self.connection.sql(f"""
+        ways_ids_grouped_relation = self.connection.sql(
+            f"""
             SELECT id,
                 floor(
                     row_number() OVER () / {self.rows_per_bucket}
                 )::INTEGER as "group",
             FROM ({ways_ids.sql_query()})
-        """)
+            """
+        )
         grouped_ways_ids_with_group_path = grouped_ways_tmp_path / "ids_with_group"
         ways_ids_grouped_relation_parquet = self._save_parquet_file(
             relation=ways_ids_grouped_relation, file_path=grouped_ways_ids_with_group_path
         )
 
-        ways_with_nodes_points_relation = self.connection.sql(f"""
+        ways_with_nodes_points_relation = self.connection.sql(
+            f"""
             SELECT
                 w.id, w.point, w.ref_idx, rw."group"
             FROM ({ways_ids_grouped_relation_parquet.sql_query()}) rw
             JOIN ({ways_refs_with_nodes_structs.sql_query()}) w
             ON rw.id = w.id
-        """)
+            """
+        )
 
         grouped_ways_ids_with_points_path = grouped_ways_tmp_path / "ids_with_points"
         ways_with_nodes_points_relation_parquet = self._save_parquet_file(
             relation=ways_with_nodes_points_relation, file_path=grouped_ways_ids_with_points_path
         )
 
-        self.connection.sql(f"""
+        self.connection.sql(
+            f"""
             COPY (
                 SELECT
                     id, point, ref_idx, "group"
@@ -1270,7 +1348,8 @@ class PbfFileReader:
                 ROW_GROUP_SIZE 25000,
                 COMPRESSION '{self.parquet_compression}'
             )
-        """)
+            """
+        )
 
         return groups
 
@@ -1285,15 +1364,17 @@ class PbfFileReader:
 
         for group in bar.track(range(groups + 1)):
             current_ways_group_path = grouped_ways_path / f"group={group}"
-            current_ways_group_relation = self.connection.sql(f"""
-                SELECT * FROM read_parquet('{current_ways_group_path}/**')
-            """)
+            current_ways_group_relation = self.connection.sql(
+                f"SELECT * FROM read_parquet('{current_ways_group_path}/**')"
+            )
 
-            ways_with_linestrings = self.connection.sql(f"""
+            ways_with_linestrings = self.connection.sql(
+                f"""
                 SELECT id, list(point ORDER BY ref_idx ASC)::LINESTRING_2D linestring
                 FROM ({current_ways_group_relation.sql_query()})
                 GROUP BY id
-            """)
+                """
+            )
             self._save_parquet_file(
                 relation=ways_with_linestrings,
                 file_path=destination_dir_path / f"group={group}",
@@ -1333,7 +1414,8 @@ class PbfFileReader:
                 f" list_has_any(map_extract(raw_tags, '{osm_tag_key}'), [{escaped_values}])"
             )
 
-        ways_with_proper_geometry = self.connection.sql(f"""
+        ways_with_proper_geometry = self.connection.sql(
+            f"""
             WITH required_ways_with_linestrings AS (
                 SELECT
                     w.id,
@@ -1370,7 +1452,8 @@ class PbfFileReader:
                     required_ways_with_linestrings w
             )
             SELECT 'way/' || id as feature_id, tags, geometry FROM proper_geometries
-        """)
+            """
+        )
         result_path = self.tmp_dir_path / "filtered_ways_with_geometry"
         self._save_parquet_file_with_geometry(
             relation=ways_with_proper_geometry,
@@ -1385,7 +1468,8 @@ class PbfFileReader:
         osm_parquet_files: ConvertedOSMParquetFiles,
         required_ways_with_linestrings: "duckdb.DuckDBPyRelation",
     ) -> Path:
-        valid_relation_parts = self.connection.sql(f"""
+        valid_relation_parts = self.connection.sql(
+            f"""
             WITH unnested_relations AS (
                 SELECT
                     r.id,
@@ -1440,18 +1524,21 @@ class PbfFileReader:
             )
             SELECT * FROM relations_with_geometries
             SEMI JOIN valid_relations ON relations_with_geometries.id = valid_relations.id
-        """)
+            """
+        )
         valid_relation_parts_parquet = self._save_parquet_file_with_geometry(
             relation=valid_relation_parts,
             file_path=self.tmp_dir_path / "valid_relation_parts",
             step_name="Saving valid relations parts",
             step_number="26",
         )
-        relation_inner_parts = self.connection.sql(f"""
+        relation_inner_parts = self.connection.sql(
+            f"""
             SELECT id, geometry_id, ST_MakePolygon(geometry) geometry
             FROM ({valid_relation_parts_parquet.sql_query()})
             WHERE ref_role = 'inner'
-        """)
+            """
+        )
         relation_inner_parts_parquet = self._save_parquet_file_with_geometry(
             relation=relation_inner_parts,
             file_path=self.tmp_dir_path / "relation_inner_parts",
@@ -1459,11 +1546,13 @@ class PbfFileReader:
             step_name="Saving relations inner parts",
             step_number="27",
         )
-        relation_outer_parts = self.connection.sql(f"""
+        relation_outer_parts = self.connection.sql(
+            f"""
             SELECT id, geometry_id, ST_MakePolygon(geometry) geometry
             FROM ({valid_relation_parts_parquet.sql_query()})
             WHERE ref_role = 'outer'
-        """)
+            """
+        )
         relation_outer_parts_parquet = self._save_parquet_file_with_geometry(
             relation=relation_outer_parts,
             file_path=self.tmp_dir_path / "relation_outer_parts",
@@ -1471,7 +1560,8 @@ class PbfFileReader:
             step_name="Saving relations outer parts",
             step_number="28",
         )
-        relation_outer_parts_with_holes = self.connection.sql(f"""
+        relation_outer_parts_with_holes = self.connection.sql(
+            f"""
             SELECT
                 og.id,
                 og.geometry_id,
@@ -1480,14 +1570,16 @@ class PbfFileReader:
             JOIN ({relation_inner_parts_parquet.sql_query()}) ig
             ON og.id = ig.id AND ST_WITHIN(ig.geometry, og.geometry)
             GROUP BY og.id, og.geometry_id
-        """)
+            """
+        )
         relation_outer_parts_with_holes_parquet = self._save_parquet_file_with_geometry(
             relation=relation_outer_parts_with_holes,
             file_path=self.tmp_dir_path / "relation_outer_parts_with_holes",
             step_name="Saving relations outer parts with holes",
             step_number="29",
         )
-        relation_outer_parts_without_holes = self.connection.sql(f"""
+        relation_outer_parts_without_holes = self.connection.sql(
+            f"""
             SELECT
                 og.id,
                 og.geometry_id,
@@ -1495,14 +1587,16 @@ class PbfFileReader:
             FROM ({relation_outer_parts_parquet.sql_query()}) og
             ANTI JOIN ({relation_outer_parts_with_holes_parquet.sql_query()}) ogwh
             ON og.id = ogwh.id AND og.geometry_id = ogwh.geometry_id
-        """)
+            """
+        )
         relation_outer_parts_without_holes_parquet = self._save_parquet_file_with_geometry(
             relation=relation_outer_parts_without_holes,
             file_path=self.tmp_dir_path / "relation_outer_parts_without_holes",
             step_name="Saving relations outer parts without holes",
             step_number="30",
         )
-        relations_with_geometry = self.connection.sql(f"""
+        relations_with_geometry = self.connection.sql(
+            f"""
             WITH unioned_outer_geometries AS (
                 SELECT id, geometry
                 FROM ({relation_outer_parts_with_holes_parquet.sql_query()})
@@ -1519,7 +1613,8 @@ class PbfFileReader:
             FROM final_geometries r_g
             JOIN ({osm_parquet_files.relations_all_with_tags.sql_query()}) r
             ON r.id = r_g.id
-        """)
+            """
+        )
 
         result_path = self.tmp_dir_path / "filtered_relations_with_geometry"
         self._save_parquet_file_with_geometry(
@@ -1540,7 +1635,8 @@ class PbfFileReader:
     ) -> "duckdb.DuckDBPyRelation":
         if not fix_geometries:
             with TaskProgressSpinner(step_name, step_number):
-                self.connection.sql(f"""
+                self.connection.sql(
+                    f"""
                     COPY (
                         SELECT
                             * EXCLUDE (geometry), ST_AsWKB(geometry) geometry_wkb
@@ -1551,7 +1647,8 @@ class PbfFileReader:
                         ROW_GROUP_SIZE 25000,
                         COMPRESSION '{self.parquet_compression}'
                     )
-                """)
+                    """
+                )
         else:
             valid_path = file_path / "valid"
             invalid_path = file_path / "invalid"
@@ -1563,7 +1660,8 @@ class PbfFileReader:
 
             # Save valid features
             with TaskProgressSpinner(f"{step_name} - valid geometries", f"{step_number}.1"):
-                self.connection.sql(f"""
+                self.connection.sql(
+                    f"""
                     COPY (
                         SELECT
                             * EXCLUDE (geometry), ST_AsWKB(geometry) geometry_wkb
@@ -1575,11 +1673,13 @@ class PbfFileReader:
                         ROW_GROUP_SIZE 25000,
                         COMPRESSION '{self.parquet_compression}'
                     )
-                """)
+                    """
+                )
 
             # Save invalid features
             with TaskProgressSpinner(f"{step_name} - invalid geometries", f"{step_number}.2"):
-                self.connection.sql(f"""
+                self.connection.sql(
+                    f"""
                     COPY (
                         SELECT
                             * EXCLUDE (geometry), ST_AsWKB(geometry) geometry_wkb,
@@ -1594,7 +1694,8 @@ class PbfFileReader:
                         ROW_GROUP_SIZE 25000,
                         COMPRESSION '{self.parquet_compression}'
                     )
-                """)
+                    """
+                )
 
             # Fix invalid features
             total_groups = 0
@@ -1634,10 +1735,12 @@ class PbfFileReader:
 
             self._delete_directories(invalid_path)
 
-        return self.connection.sql(f"""
+        return self.connection.sql(
+            f"""
             SELECT * EXCLUDE (geometry_wkb), ST_GeomFromWKB(geometry_wkb) geometry
             FROM read_parquet('{file_path}/**')
-        """)
+            """
+        )
 
     def _concatenate_results_to_geoparquet(
         self,
@@ -1654,19 +1757,23 @@ class PbfFileReader:
             "ST_GeomFromWKB(geometry_wkb) AS geometry",
         ]
 
-        unioned_features = self.connection.sql(f"""
+        unioned_features = self.connection.sql(
+            f"""
             SELECT {', '.join(select_clauses)}
             FROM ({parsed_geometries.sql_query()})
-        """)
+            """
+        )
 
         grouped_features = self._parse_features_relation_to_groups(
             unioned_features, keep_all_tags=keep_all_tags, explode_tags=explode_tags
         )
 
-        valid_features_full_relation = self.connection.sql(f"""
+        valid_features_full_relation = self.connection.sql(
+            f"""
             SELECT * FROM ({grouped_features.sql_query()})
             WHERE ST_IsValid(geometry)
-        """)
+            """
+        )
 
         valid_features_parquet_path = self.tmp_dir_path / "osm_valid_elements"
         valid_features_parquet_relation = self._save_parquet_file_with_geometry(
@@ -1693,11 +1800,13 @@ class PbfFileReader:
 
         parquet_tables = [valid_features_parquet_table]
 
-        invalid_features_full_relation = self.connection.sql(f"""
+        invalid_features_full_relation = self.connection.sql(
+            f"""
             SELECT * FROM ({grouped_features.sql_query()}) a
             ANTI JOIN ({valid_features_parquet_relation.sql_query()}) b
             ON a.feature_id = b.feature_id
-        """)
+            """
+        )
 
         total_features = parsed_geometries.count("feature_id").fetchone()[0]
 
@@ -1711,7 +1820,8 @@ class PbfFileReader:
                 grouped_invalid_features_result_parquet = (
                     self.tmp_dir_path / "osm_invalid_elements_grouped"
                 )
-                self.connection.sql(f"""
+                self.connection.sql(
+                    f"""
                     COPY (
                         SELECT
                             * EXCLUDE (geometry), ST_AsWKB(geometry) geometry_wkb,
@@ -1725,7 +1835,8 @@ class PbfFileReader:
                         ROW_GROUP_SIZE 25000,
                         COMPRESSION '{self.parquet_compression}'
                     )
-                """)
+                    """
+                )
 
             with TaskProgressBar("Fixing invalid features", "32.3") as bar:
                 for group in bar.track(range(groups + 1)):
@@ -1794,10 +1905,15 @@ class PbfFileReader:
             osm_tag_keys_select_clauses = ["tags"]
         elif (no_tags_filter and explode_tags) or (tags_filter_and_keep_all_tags and explode_tags):
             osm_tag_keys = set()
-            found_tag_keys = [row[0] for row in self.connection.sql(f"""
-                SELECT DISTINCT UNNEST(map_keys(tags)) tag_key
-                FROM ({parsed_geometries.sql_query()})
-            """).fetchall()]
+            found_tag_keys = [
+                row[0]
+                for row in self.connection.sql(
+                    f"""
+                    SELECT DISTINCT UNNEST(map_keys(tags)) tag_key
+                    FROM ({parsed_geometries.sql_query()})
+                    """
+                ).fetchall()
+            ]
             osm_tag_keys.update(found_tag_keys)
             osm_tag_keys_select_clauses = [
                 f"list_extract(map_extract(tags, '{osm_tag_key}'), 1) as \"{osm_tag_key}\""
@@ -1820,7 +1936,8 @@ class PbfFileReader:
                         f"(tag_entry.key = '{filter_tag_key}' AND tag_entry.value IN"
                         f" ({', '.join(values_list)}))"
                     )
-            osm_tag_keys_select_clauses = [f"""
+            osm_tag_keys_select_clauses = [
+                f"""
                 map_from_entries(
                     [
                         tag_entry
@@ -1828,7 +1945,8 @@ class PbfFileReader:
                         if {" OR ".join(filter_tag_clauses)}
                     ]
                 ) as tags
-            """]
+                """
+            ]
         elif self.merged_tags_filter and explode_tags:
             for filter_tag_key, filter_tag_value in self.merged_tags_filter.items():
                 if isinstance(filter_tag_value, bool) and filter_tag_value:
@@ -1838,24 +1956,28 @@ class PbfFileReader:
                     )
                 elif isinstance(filter_tag_value, str):
                     escaped_value = self._sql_escape(filter_tag_value)
-                    osm_tag_keys_select_clauses.append(f"""
+                    osm_tag_keys_select_clauses.append(
+                        f"""
                         CASE WHEN list_extract(
                             map_extract(tags, '{filter_tag_key}'), 1
                         ) = '{escaped_value}'
                         THEN '{escaped_value}'
                         ELSE NULL
                         END as "{filter_tag_key}"
-                    """)
+                        """
+                    )
                 elif isinstance(filter_tag_value, list) and filter_tag_value:
                     values_list = [f"'{self._sql_escape(value)}'" for value in filter_tag_value]
-                    osm_tag_keys_select_clauses.append(f"""
+                    osm_tag_keys_select_clauses.append(
+                        f"""
                         CASE WHEN list_extract(
                             map_extract(tags, '{filter_tag_key}'), 1
                         ) IN ({', '.join(values_list)})
                         THEN list_extract(map_extract(tags, '{filter_tag_key}'), 1)
                         ELSE NULL
                         END as "{filter_tag_key}"
-                    """)
+                        """
+                    )
 
         if len(osm_tag_keys_select_clauses) > 100:
             warnings.warn(
@@ -1931,10 +2053,12 @@ class PbfFileReader:
                 case_clauses.append(case_clause)
 
             joined_case_clauses = ", ".join(case_clauses)
-            grouped_features_relation = self.connection.sql(f"""
+            grouped_features_relation = self.connection.sql(
+                f"""
                 SELECT feature_id, {joined_case_clauses}, geometry
                 FROM ({features_relation.sql_query()})
-            """)
+                """
+            )
         else:
             case_clauses = []
             group_names = sorted(grouped_tags_filter.keys())
@@ -1975,9 +2099,11 @@ class PbfFileReader:
                 ]
             ) as tags"""
 
-            grouped_features_relation = self.connection.sql(f"""
+            grouped_features_relation = self.connection.sql(
+                f"""
                 SELECT feature_id, {non_null_groups_map}, geometry
                 FROM ({features_relation.sql_query()})
-            """)
+                """
+            )
 
         return grouped_features_relation

--- a/tests/base/test_pbf_file_reader.py
+++ b/tests/base/test_pbf_file_reader.py
@@ -489,7 +489,6 @@ def check_if_relation_in_osm_is_valid_based_on_geometry(pbf_file: str, relation_
                     COALESCE(r.ref_role, 'outer') as ref_role,
                     r.ref,
                 FROM unnested_relation_way_refs r
-                ORDER BY r.id, r.ref_idx
             ),
             unnested_way_refs AS (
                 SELECT

--- a/tests/base/test_pbf_file_reader.py
+++ b/tests/base/test_pbf_file_reader.py
@@ -452,7 +452,8 @@ def check_if_relation_in_osm_is_valid_based_on_geometry(pbf_file: str, relation_
     duckdb.load_extension("spatial")
     return cast(
         bool,
-        duckdb.sql(f"""
+        duckdb.sql(
+            f"""
             WITH required_relation AS (
                 SELECT
                     r.id
@@ -561,7 +562,8 @@ def check_if_relation_in_osm_is_valid_based_on_geometry(pbf_file: str, relation_
             )
             SELECT COUNT(*) > 0 AS 'any_valid_outer_geometry'
             FROM valid_relations
-        """).fetchone()[0],
+            """
+        ).fetchone()[0],
     )
 
 

--- a/tests/benchmark/test_big_file.py
+++ b/tests/benchmark/test_big_file.py
@@ -20,6 +20,7 @@ def test_big_file(extract_name: str) -> None:
         f"https://download.geofabrik.de/europe/{extract_name}-latest.osm.pbf", str(file_name)
     )
 
-    PbfFileReader(working_directory=files_dir).convert_pbf_to_gpq(
-        pbf_path=file_name, ignore_cache=True
-    )
+    reader = PbfFileReader(working_directory=files_dir)
+    # Reset rows_per_bucket value to test automatic downscaling
+    reader.rows_per_bucket = PbfFileReader.ROWS_PER_BUCKET_MEMORY_CONFIG[24]
+    reader.convert_pbf_to_gpq(pbf_path=file_name, ignore_cache=True)

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     coverage
     pre-commit
 commands =
-    coverage run --data-file=.coverage.doc.tests --source=quackosm -m pytest -v -s --durations=20 --doctest-modules --doctest-continue-on-failure quackosm
+    ; coverage run --data-file=.coverage.doc.tests --source=quackosm -m pytest -v -s --durations=20 --doctest-modules --doctest-continue-on-failure quackosm
     coverage run --data-file=.coverage.base.tests --source=quackosm -m pytest -v -s --durations=20 tests/base
     coverage run --data-file=.coverage.benchmark.tests --source=quackosm -m pytest -v -s --durations=20 tests/benchmark
     coverage combine

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     coverage
     pre-commit
 commands =
-    ; coverage run --data-file=.coverage.doc.tests --source=quackosm -m pytest -v -s --durations=20 --doctest-modules --doctest-continue-on-failure quackosm
+    coverage run --data-file=.coverage.doc.tests --source=quackosm -m pytest -v -s --durations=20 --doctest-modules --doctest-continue-on-failure quackosm
     coverage run --data-file=.coverage.base.tests --source=quackosm -m pytest -v -s --durations=20 tests/base
     coverage run --data-file=.coverage.benchmark.tests --source=quackosm -m pytest -v -s --durations=20 tests/benchmark
     coverage combine


### PR DESCRIPTION
Closes #50

Grouping nodes into ways is the most memory-intensive operation for the whole algorithm. Currently, it's more or less tuned based on the system's available memory. This change will catch OOM errors, downscale the process and retry the operation.