### PR TITLE
Update duckdb version constraint to allow use with python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "geopandas",
     "shapely>=2",
     "pyarrow>=13.0.0",
-    "duckdb==0.9.2",
+    "duckdb>=0.9.2",
     "geoarrow-pyarrow>=0.1.2",
     "typeguard",
     "psutil",


### PR DESCRIPTION
Currently, there is `duckdb==0.9.2` however 0.9.2 does not work with python 3.12 (https://github.com/duckdb/duckdb/issues/9301#issuecomment-1837045418). 

Relaxing the constraint allows quackosm to successfully install with python 3.12.