### PR TITLE
Allow overriding the default ZSTD compression levels from command line

### DIFF
--- a/quackosm/cli.py
+++ b/quackosm/cli.py
@@ -9,10 +9,7 @@ import click
 import typer
 from rq_geo_toolkit._geopandas_api_version import GEOPANDAS_NEW_API
 
-from quackosm._constants import (
-    PARQUET_COMPRESSION_LEVEL
-)
-
+from quackosm._constants import PARQUET_COMPRESSION_LEVEL
 from quackosm._osm_tags_filters import GroupedOsmTagsFilter, OsmTagsFilter
 from quackosm.osm_extracts.extract import OsmExtractSource
 from quackosm.pbf_file_reader import _is_url_path
@@ -574,9 +571,7 @@ def main(
         bool,
         typer.Option(
             "--compression-level",
-            help=(
-                "ZSTD compression level from 0-22 for the output parquet file"
-            ),
+            help=("ZSTD compression level from 0-22 for the output parquet file"),
         ),
     ] = PARQUET_COMPRESSION_LEVEL,
     ignore_cache: Annotated[


### PR DESCRIPTION
Like mentioned in the issue #247 this would help producing a lot smaller files in cases where user has enough compute to spare.