### PR TITLE
fix: always clean directories after error in ways grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added directories cleaning after every error in ways grouping operation
+
 ## [0.18.0] - 2026-06-17
 
 ### Added

--- a/quackosm/pbf_file_reader.py
+++ b/quackosm/pbf_file_reader.py
@@ -2974,6 +2974,9 @@ class PbfFileReader:
                 if not grouped_ways:
                     self.encountered_query_exception = True
                 self.task_progress_tracker.major_step_number -= reset_steps
+                self._delete_directories(
+                    [destination_dir_path, grouped_ways_tmp_path, grouped_ways_path]
+                )
                 if not lower_number_of_rows:
                     if not self.verbosity_mode == "silent":
                         log_message(
@@ -2981,9 +2984,6 @@ class PbfFileReader:
                             " Retrying with another grouping method."
                         )
                 elif self.internal_rows_per_group > PbfFileReader.ROWS_PER_GROUP_MEMORY_CONFIG[0]:
-                    self._delete_directories(
-                        [destination_dir_path, grouped_ways_tmp_path, grouped_ways_path]
-                    )
                     smaller_rows_per_group = 0
                     for rows_per_group in PbfFileReader.ROWS_PER_GROUP_MEMORY_CONFIG.values():
                         if rows_per_group < self.internal_rows_per_group:

--- a/tests/base/test_pbf_file_reader.py
+++ b/tests/base/test_pbf_file_reader.py
@@ -350,6 +350,87 @@ def test_combining_files_different_techniques(
         raise ValueError("Wrong operation_mode value.")
 
 
+def test_ways_grouping_retry_another_grouping_method_removes_stale_files(
+    mocker: MockerFixture,
+) -> None:
+    """Test if retrying with another grouping method removes stale tmp files before the retry."""
+    monaco_file_path = Path(__file__).parent.parent / "test_files" / "monaco.osm.pbf"
+    original_save_parquet_file = PbfFileReader._save_parquet_file
+    state: dict[str, Any] = {"crashed": False, "stale_path": None}
+
+    def flaky_save_parquet_file(
+        self: PbfFileReader, relation: Any, file_path: Path, *args: Any, **kwargs: Any
+    ) -> Any:
+        if file_path.name == "ids_with_points" and not state["crashed"]:
+            state["crashed"] = True
+            file_path.mkdir(parents=True, exist_ok=True)
+            state["stale_path"] = file_path / "data_0.parquet"
+            state["stale_path"].write_bytes(b"not actually a parquet file")
+            raise MemoryError()
+        return original_save_parquet_file(self, relation, file_path, *args, **kwargs)
+
+    mocker.patch.object(PbfFileReader, "_save_parquet_file", flaky_save_parquet_file)
+
+    result_gdf = convert_pbf_to_geodataframe(pbf_path=monaco_file_path, ignore_cache=True)
+
+    assert state["crashed"], "The injected MemoryError never fired - test setup is stale."
+    assert not (
+        state["stale_path"].exists()
+        and state["stale_path"].read_bytes() == b"not actually a parquet file"
+    ), "Stale file from the crashed attempt leaked into the retry."
+    assert result_gdf.index.is_unique
+
+
+def test_ways_grouping_retry_lower_rows_per_group_removes_stale_files(
+    mocker: MockerFixture,
+) -> None:
+    """Test if retrying with a lower rows-per-group value removes stale files before the retry."""
+    monaco_file_path = Path(__file__).parent.parent / "test_files" / "monaco.osm.pbf"
+    # Force a memory tier above the minimum, otherwise the except block hits
+    # `else: raise` instead of retrying, regardless of the runner's actual RAM.
+    mocker.patch(
+        "quackosm.pbf_file_reader.psutil.virtual_memory",
+        return_value=mocker.Mock(total=64 * 1024**3, percent=10.0),
+    )
+    original_construct_ways_linestrings = PbfFileReader._construct_ways_linestrings
+    state: dict[str, Any] = {"crashed": False, "stale_path": None}
+
+    def flaky_construct_ways_linestrings(
+        self: PbfFileReader,
+        bar: Any,
+        groups: int,
+        destination_dir_path: Path,
+        grouped_ways_path: Path,
+    ) -> Any:
+        if not state["crashed"]:
+            state["crashed"] = True
+            group_dir = destination_dir_path / "group=0"
+            group_dir.mkdir(parents=True, exist_ok=True)
+            state["stale_path"] = group_dir / "data_0.parquet"
+            state["stale_path"].write_bytes(b"not actually a parquet file")
+            raise MemoryError()
+        return original_construct_ways_linestrings(
+            self,
+            bar=bar,
+            groups=groups,
+            destination_dir_path=destination_dir_path,
+            grouped_ways_path=grouped_ways_path,
+        )
+
+    mocker.patch.object(
+        PbfFileReader, "_construct_ways_linestrings", flaky_construct_ways_linestrings
+    )
+
+    result_gdf = convert_pbf_to_geodataframe(pbf_path=monaco_file_path, ignore_cache=True)
+
+    assert state["crashed"]
+    assert not (
+        state["stale_path"].exists()
+        and state["stale_path"].read_bytes() == b"not actually a parquet file"
+    )
+    assert result_gdf.index.is_unique
+
+
 def test_schema_unification_real_example() -> None:
     """
     Test if function returns results with unified schema without errors.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from processing failures by consistently cleaning up temporary way-grouping directories before retrying.
  * Enhanced reliability when switching grouping methods or adjusting internal processing limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->